### PR TITLE
CASMINST-3525: remove branch protections instead of enabling push

### DIFF
--- a/import.py
+++ b/import.py
@@ -179,18 +179,16 @@ def find_base_branch(base_branch, git_repo, gitea_repo, product_version, branch_
     return base_branch
 
 
-def enable_gitea_branch_push(branch, repo_name, org, gitea_url, session):
-    """ Set a Gitea branch to not be protected from pushes """
+def remove_gitea_branch_protections(branch, repo_name, org, gitea_url, session):
+    """ Set a Gitea branch to not be protected (from pushes, etc) """
     url = '{}/repos/{}/{}/branch_protections/{}'.format(
         gitea_url, org, repo_name, quote(branch, safe='')
     )
-    opts = { 'enable_push': True }
-    LOGGER.info("Allowing branch push: %s", url)
-    resp = session.patch(url, json=opts)
+    LOGGER.info("Removing branch protections push: %s", url)
+    resp = session.delete(url)
     if not resp.ok:
-        LOGGER.warning("Enabling branch push failed with status=%s, ignoring...", resp.status_code)
-        LOGGER.info("Ignoring...")
-        return
+        LOGGER.warning("Removing branch protections failed with status=%s, ignoring...", resp.status_code)
+    return
 
 
 def protect_gitea_branch(branch, repo_name, org, gitea_url, session):
@@ -352,7 +350,7 @@ if __name__ == "__main__":
 
     # Do the work to import the content to the repository, if the branch
     # already exists and is protected, remove the protections first.
-    enable_gitea_branch_push(target_branch, repo_name, org, gitea_url, session)
+    remove_gitea_branch_protections(target_branch, repo_name, org, gitea_url, session)
     commit_msg = "Import of %r product version %s" % (product_name, product_version)  # noqa: E501
     update_content(
         base_branch, target_branch, git_repo, product_content_dir,


### PR DESCRIPTION
## Summary and Scope

Previously, when a branch already existed the was being pushed,
the import.py script used the Gitea API to enable pushes to the
repository after branches had been protected from a previous import.
When the branch does not change, ie a new version of CSM, but not a
new version of csm-import, a force push happens, but branch protections
that allow pushing on a protected branch do not allow force pushes.
To remedy this, instead of just enabling push, remove the branch
protections altogether, force push the branch, and then re-enable
branch protections if requested.

This is a backwards compatible change.

## Issues and Related PRs

* Resolves [CASMINST-3525](https://connect.us.cray.com/jira/browse/CASMINST-3525)
* Change will also be needed in `csm-config release/csm-1.0` See https://github.com/Cray-HPE/csm-config/pull/25

## Testing

### Tested on:

  * `drax`

### Test description:

Rebuilt csm-config image/chart with this change and ran the chart on Drax. Successfully ran the new chart which attempted to force push the same branch. Code successfully removed branch protections, force pushed, and re-enabled branch protections.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? No
- Was upgrade tested? Yes
- Was downgrade tested? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

N/A


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable