### PR TITLE
hotfix 1.5.3: push all image tags to registry

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -184,7 +184,7 @@ jobs:
         with:
           name: docker-image
           path: docker-image.tar.gz
-          retention-days: 7
+          retention-days: 90
 
       # Run the scanner, continue on if errors are found so the results can be
       # reported to the Github Code Scanning alerts tab
@@ -220,13 +220,14 @@ jobs:
           username: ${{ env.REGISTRY_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
 
-      - name: Push Image to Registry
+      - name: Push Image tags to registry
         if: ${{ fromJSON(steps.snyk-result.outputs.snyk-passed) }}
-        shell: bash
-        run: 
-          docker push ${{ env.IMAGE }}
-        env:
-          IMAGE: ${{ steps.buildvars.outputs.full-image }}
+        uses: docker/build-push-action@v2
+        id: push-docker-image
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   sign-image-sbom:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.3] - 2022-02-15
+
+### Added
+
+- Push all tags to registry, not just the semver+builddate+sha tag.
+
 ## [1.5.2] - 2022-02-08
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Previously the build artifacts workflow only pushed the docker image with format `image:x.y.z-builddate.sha`, even though the `image:x` and `image:y` tags were also built. This change pushes all three.

## Testing

Tested that this does not break current pushing, but there is no way to test this unless we create a stable release.

## Risks and Mitigations

N/A


## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

