### PR TITLE
CASMINST-4145 - update alpine base image for CVE remediation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Dockerfile to use alpine:3.15 for CVE remediation.
 
 ## [1.5.4] - 2022-03-01
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # (MIT License)
-FROM artifactory.algol60.net/docker.io/alpine:3.13 as base
+FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
 WORKDIR /
 
 # Supported Environment Variables (see README in this repository)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Dockerfile for importing content into gitea instances on Shasta
 # Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #


### PR DESCRIPTION
## Summary and Scope

Update the alpine base image to version to  3.15 to resolve CVE vulnerbilities.
 
## Issues and Related PRs

* Resolves [CASMINST-4145](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4145)

## Testing
### Tested on:
  * `Drax`
  * Local development environment

### Test description:

Local snyk scan shows the new image to be free of vulnerabilities.  We upgraded drax to use the new version and verified that is worked correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This is a low risk change just changing a base image version.

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

