### PR TITLE
Use github public ubuntu runner instead of self-hosted on public repos.

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -90,7 +90,7 @@ on:
 jobs:
 
   build-prep:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       semVer: ${{ steps.buildprepversion.outputs.version }}
       image-version: ${{ steps.buildversion.outputs.image-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.7] - 2022-03-04
+
+### Changed
+
+- Use github public ubuntu runner instead of self-hosted on public repos.
+
 ## [1.5.6] - 2022-03-03
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Use github public ubuntu runner instead of self-hosted on public repos.

## Issues and Related PRs

* Resolves CASMCMS-7878

## Testing

Image build correctly in pipeline with proper version

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

