### PR TITLE
CASMCMS-7309: Add 500 status code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,5 +43,6 @@ _Are there known issues with these changes? Any other special considerations?_
 
 - [ ] Target branch correct
 - [ ] Testing is appropriate and complete, if applicable
+- [ ] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
 - [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CASMCMS-7309: Add the 500 status code to the list of http codes to retry
+
 ### Changed
+
 - Update license text to comply with automatic license-check tool.
 
 ## [1.6.0] - 2022-03-08
@@ -15,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Handle repeated import attempts gracefully when the product version has not
-  changed. Introduce CF_IMPORT_FORCE_EXISTING_BRANCH parameter (default false) to
+  changed. Introduce `CF_IMPORT_FORCE_EXISTING_BRANCH` parameter (default false) to
   allow override of this behavior.
 
 - Add test capabilities to bring up Gitea instance for manual testing. See

--- a/import.py
+++ b/import.py
@@ -323,7 +323,7 @@ if __name__ == "__main__":
 
     # Setup talking to the Gitea REST API, auth, user-agent, retries
     retries = Retry(
-        total=50, backoff_factor=1.1, status_forcelist=[502, 503, 504]
+        total=50, backoff_factor=1.1, status_forcelist=[500, 502, 503, 504]
     )
     session = Session()
     session.auth = (gitea_user, gitea_password)


### PR DESCRIPTION
## Summary and Scope

Add the 500 status code to the list of http codes to retry

## Issues and Related PRs

* Resolves CASMCMS-7309

## Testing

No tests were added or run for this change.

## Risks and Mitigations

Low, a 500 status code has rarely been seen except when there is a problem with Gitea.


## Pull Request Checklist

- [x] Target branch correct
