### PR TITLE
CASMINST-4500: Fix workdir for changes to git behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CASMINST-4500: Fix git workdir for changes to git behavior as part of fixing
+  [a security vulnerability](https://github.blog/2022-04-12-git-security-vulnerability-announced/).
 - Update license text to comply with automatic license-check tool.
 
 ## [1.6.0] - 2022-03-08

--- a/import.py
+++ b/import.py
@@ -356,7 +356,7 @@ if __name__ == "__main__":
     gitea_repo = get_gitea_repository(repo_name, org, gitea_url, session)
 
     # Create a local git workspace
-    git_workdir = tempfile.gettempdir()
+    git_workdir = tempfile.gettempdir() + '/' + product_name
 
     # Clone the repository
     git_repo = clone_repo(


### PR DESCRIPTION
## Summary and Scope

Recently the following git security vulnerability was patched in a new version of git:
https://github.blog/2022-04-12-git-security-vulnerability-announced/

The cf-gitea-import image picked up this fix with a rebuild earlier this week. This ended up breaking the import jobs from working on the system. The symptom is is that the `csm-config-import-*` pods end up in the Error state, with the following in their logs:
```
2022-04-22 12:29:11,030 - cf-gitea-import - INFO - Searching for a previous branch by semver version.
Traceback (most recent call last):
  File "/opt/csm/cf-gitea-import/./import.py", line 367, in <module>
    base_branch = find_base_branch(
  File "/opt/csm/cf-gitea-import/./import.py", line 142, in find_base_branch
    for ref in git_repo.git.branch('-r').split():
  File "/usr/lib/python3.9/site-packages/git/cmd.py", line 639, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/git/cmd.py", line 1184, in _call_process
    return self.execute(call, **exec_kwargs)
  File "/usr/lib/python3.9/site-packages/git/cmd.py", line 984, in execute
    raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git branch -r
  stderr: 'fatal: unsafe repository ('/tmp' is owned by someone else) 
```

The fix is to not clone to /tmp but instead clone to a subdirectory off /tmp.

Ryan Bak made the commit with the fix. But he is now on vacation, so I will carry through his noble vision to completion.

## Issues and Related PRs

* Resolves [CASMINST-4498](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4498), [CASMINST-4500](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4500)

## Testing

I built a csm-config image using this fixed cf-gitea-import image and then tested it on surtur (where the import job had been failing). The import job passed without issue with this fix in place.

## Risks and Mitigations

The risk is low, and certainly better than shipping with a non-functional import image, or with a security vulnerability in it.

## Pull Request Checklist

- [X] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
