### PR TITLE
CRAYSAT-1512: cf-gitea-import enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CRAYSAT-1512: Fixed a bug in which the VCS API URL was not formed correctly
+  when the base URL contained path components in it.
+
 ## [1.6.2] - 2022-04-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CRAYSAT-1512: Fixed a bug in which the VCS API URL was not formed correctly
   when the base URL contained path components in it.
 
+### Added
+
+- CRAYSAT-1512: Add an alternate entrypoint so that cf-gitea-import can be
+  run directly without waiting on the envoy proxy.
+
 ## [1.6.2] - 2022-04-23
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,5 +67,5 @@ RUN pip3 install --no-cache-dir -r requirements.txt && \
 
 USER nobody:nobody
 RUN mkdir -p ${CF_IMPORT_CONTENT} /opt/csm/cf-gitea-import /results
-ADD entrypoint.sh import.py /opt/csm/cf-gitea-import/
+ADD entrypoint.sh standalone_entrypoint.sh import.py /opt/csm/cf-gitea-import/
 ENTRYPOINT ["/opt/csm/cf-gitea-import/entrypoint.sh"]

--- a/import.py
+++ b/import.py
@@ -36,7 +36,7 @@ import os.path
 import sys
 import tempfile
 import time
-from urllib.parse import urljoin, urlparse, urlunparse, quote
+from urllib.parse import urlparse, urlunparse, quote
 import yaml
 
 from git import Repo
@@ -44,7 +44,6 @@ from git.exc import GitCommandError
 import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
-from requests.auth import HTTPBasicAuth
 from requests.packages.urllib3.util.retry import Retry
 import semver
 
@@ -314,7 +313,7 @@ if __name__ == "__main__":
     force_existing_branch = True if os.environ.get('CF_IMPORT_FORCE_EXISTING_BRANCH', 'false').strip().lower() == "true" else False  # noqa: E501
     protect_branch = True if os.environ.get('CF_IMPORT_PROTECT_BRANCH', 'true').strip().lower() == "true" else False  # noqa: E501
     repo_privacy = True if os.environ.get('CF_IMPORT_PRIVATE_REPO', 'true').strip().lower() == "true" else False  # noqa: E501
-    gitea_url = urljoin(gitea_base_url, '/api/v1')
+    gitea_url = f'{gitea_base_url.rstrip("/")}/api/v1'
     org = os.environ.get('CF_IMPORT_GITEA_ORG', 'cray').strip()
     repo_name = os.environ.get('CF_IMPORT_GITEA_REPO', product_name + '-config-management').strip()  # noqa: E501
     gitea_user = os.environ.get('CF_IMPORT_GITEA_USER', 'crayvcs').strip()

--- a/standalone_entrypoint.sh
+++ b/standalone_entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Entrypoint for running cf-gitea-import as a standalone image, e.g.
+# via podman.
+#
+# This is different from the default entrypoint in the following ways:
+# Unlike the default entrypoint, this does not wait on the envoy
+# proxy sidecar. Additionally, it does not wait for the Gitea API
+# to be available, as this is already in import.py. There is no
+# use of the /shared directory as this is specified as a volumeMount
+# in the cray-import-config Helm chart, not something in the base
+# image. Finally, there is a step to import the host's CA certificates,
+# required when running outside of Kubernetes.
+
+set -e
+#
+# update-ca-certficates reads from /usr/local/share/ca-certificates
+# and updates /etc/ssl/certs/ca-certificates.crt
+# REQUESTS_CA_BUNDLE is used by python
+#
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+update-ca-certificates 2>/dev/null
+
+# Import configuration content
+python3 /opt/csm/cf-gitea-import/import.py


### PR DESCRIPTION
## Summary and Scope

* Fix a bug that was preventing cf-gitea-import from working when the value of CF_IMPORT_GITEA_URL had trailing components, e.g. "https://api-gw-service-nmn.local/vcs", caused by a slightly incorrect use of `urljoin`.
* Add an alternate entrypoint that does not wait on the Envoy sidecar proxy to be available, which allows cf-gitea-import to be run directly via podman, if a product install mounts the ansible content to import.
* This change does not change the default entrypoint and the image continues to work in the "old" way, in which a product-specific image is derived from cf-gitea-import.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1512](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1512)

## Testing

### Tested on:

* groot

### Test description:

* Built the image.
* Built a version of sat-cfs-install derived from this image, and used
   a loftsman manifest and helm chart to import a version of SAT
   configuration.
* Built a version of the product stream with this image, Ran cf-gitea-import
   directly using podman, mounting in a version of SAT configuration
   over `/content`.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable