### PR TITLE
CASMINST-5954: Gracefully exit rm git command error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- CASMINST-5954: Handle `git rm -rf *` gracefully for empty branch scenarios
+
 ## [1.9.0] - 2023-02-01
 
 - CASMINST-5876: Handle `CF_IMPORT_GITEA_REPO` properly when it is the empty string


### PR DESCRIPTION
## Summary and Scope

- Fixes handling `rm -rf *` git failure if working with empty directory

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8360](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8360)
* Resolves [CASMINST-5954](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5954)

## Testing

Tested on Frigg - Argo logs show that the directory logs it is empty instead of a hard crash on a `git rm -rf *`
```
INFO - Checking out target_branch: cray/cos/3.0.0
INFO - target_branch cray/cos/3.0.0 is empty
WARNING - [('/content/.wh.overlay-preload.yml', '/tmp/cos/.wh.overlay-preload.yml', "[Errno 13] Permission denied: '/content/.wh.overlay-preload.
yml'"), ('/content/.wh.msr-safe.yml', '/tmp/cos/.wh.msr-safe.yml', "[Errno 13] Permission denied: '/content/.wh.msr-safe.yml'")]
INFO - Committing changes to branch with message: Import of 'cos' product version 3.0.0
INFO - Pushing content to target branch: cray/cos/3.0.0
INFO - Protecting branch from modification: https://api-gw-service-nmn.local/vcs/api/v1/repos/cray/cos-config-management/branch_protections
INFO - configuration:
  clone_url: https://vcs.cmn.frigg.dev.cray.com/vcs/cray/cos-config-management.git
  commit: 2f6ca3c682ebe06637ec61304e7758b1cfa6e68a
  import_branch: cray/cos/3.0.0
  import_date: 2023-02-09 23:49:57.196122
  ssh_url: git@vcs.cmn.frigg.dev.cray.com:cray/cos-config-management.git
```

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

