### PR TITLE
CASMINST-5866: IUF logging and skip non semver fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CASMINST-5866: Adjust log levels for IUF CLI handling
+- CASMINST-5866: Handle and skip non-semver branch names gracefully
+
 ## [1.8.0] - 2023-01-19
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

IUF CLI requires that the format of the log messages be changed so that the level is first in the message.

Some products have non-semver branch names currently installed on systems, handling a case to log and
skip over to ensure backwards compatibility with regards to IUF.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5866](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5866)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Frigg`

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

