### PR TITLE
CASMINST-5843: Python requests certs fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.1] - 2023-01-30
+## Unreleased
 
-- CASMINST-5866: Adjust log levels for IUF CLI handling
-- CASMINST-5866: Handle and skip non-semver branch names gracefully
+- CASMINST-5843: Fixing permissions for certs directory for nobody user
+
+## [1.8.1] - 2023-01-30
 
 - CASMINST-5866: Adjust log levels for IUF CLI handling
 - CASMINST-5866: Handle and skip non-semver branch names gracefully

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,9 @@ RUN pip3 install --no-cache-dir -r requirements.txt && \
     mkdir -p /opt/csm && \
     chown nobody:nobody /opt/csm
 
+# For update-ca-certificates at runtime
+RUN chown nobody:nobody /etc/ssl/certs
+
 USER nobody:nobody
 RUN mkdir -p ${CF_IMPORT_CONTENT} /opt/csm/cf-gitea-import /results
 ADD entrypoint.sh standalone_entrypoint.sh argo_entrypoint.sh import.py /opt/csm/cf-gitea-import/

--- a/argo_entrypoint.sh
+++ b/argo_entrypoint.sh
@@ -25,6 +25,16 @@
 
 # Argo specific entrypoint due to istio sidecar incompatibilities.
 # Wait for the Gitea API to be available
+
+set -e
+#
+# update-ca-certificates reads from /usr/local/share/ca-certificates
+# and updates /etc/ssl/certs/ca-certificates.crt
+# REQUESTS_CA_BUNDLE is used by python
+#
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+update-ca-certificates --fresh 2>/dev/null
+
 until curl --head ${CF_IMPORT_GITEA_URL}; \
 do
   echo Waiting for Gitea API to be available; \
@@ -32,10 +42,10 @@ do
 done; \
 echo Gitea API available;
 
-# Overwrite content before import
-cp -r /shared/* ${CF_IMPORT_CONTENT}/;
+# # Overwrite content before import
+# cp -r "/shared/"* ${CF_IMPORT_CONTENT}/ || true
+cp -r "/shared/"* ${CF_IMPORT_CONTENT}/ && echo "overwriting /content success" || echo "overwriting /content failed"
 
 # Import the configuration content
 cd /opt/csm/cf-gitea-import
 python3 ./import.py
-

--- a/argo_entrypoint.sh
+++ b/argo_entrypoint.sh
@@ -42,8 +42,7 @@ do
 done; \
 echo Gitea API available;
 
-# # Overwrite content before import
-# cp -r "/shared/"* ${CF_IMPORT_CONTENT}/ || true
+# Overwrite content before import
 cp -r "/shared/"* ${CF_IMPORT_CONTENT}/ && echo "overwriting /content success" || echo "overwriting /content failed"
 
 # Import the configuration content


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

There is a permission issue with the /etc/ssl/certs directory at runtime when running as the nobody user in Docker. In order to run update-ca-certificates on entrypoint and add any new certs.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5843)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `frigg`

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

