### PR TITLE
CASMINST-5876: Fix `CF_IMPORT_GITEA_REPO` empty string behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.9.0] - 2023-02-01
 
+- CASMINST-5876: Handle `CF_IMPORT_GITEA_REPO` properly when it is the empty string
 - CASMINST-5843: Fixing permissions for certs directory for nobody user
 
 ## [1.8.1] - 2023-01-30

--- a/import.py
+++ b/import.py
@@ -339,7 +339,7 @@ if __name__ == "__main__":
     repo_privacy = True if os.environ.get('CF_IMPORT_PRIVATE_REPO', 'true').strip().lower() == "true" else False  # noqa: E501
     gitea_url = f'{gitea_base_url.rstrip("/")}/api/v1'
     org = os.environ.get('CF_IMPORT_GITEA_ORG', 'cray').strip()
-    repo_name = os.environ.get('CF_IMPORT_GITEA_REPO').strip()  # noqa: E501
+    repo_name = os.environ.get('CF_IMPORT_GITEA_REPO', '').strip()  # noqa: E501
     if not repo_name:
         repo_name = product_name + '-config-management'
     gitea_user = os.environ.get('CF_IMPORT_GITEA_USER', 'crayvcs').strip()

--- a/import.py
+++ b/import.py
@@ -339,7 +339,9 @@ if __name__ == "__main__":
     repo_privacy = True if os.environ.get('CF_IMPORT_PRIVATE_REPO', 'true').strip().lower() == "true" else False  # noqa: E501
     gitea_url = f'{gitea_base_url.rstrip("/")}/api/v1'
     org = os.environ.get('CF_IMPORT_GITEA_ORG', 'cray').strip()
-    repo_name = os.environ.get('CF_IMPORT_GITEA_REPO', product_name + '-config-management').strip()  # noqa: E501
+    repo_name = os.environ.get('CF_IMPORT_GITEA_REPO').strip()  # noqa: E501
+    if not repo_name:
+        repo_name = product_name + '-config-management'
     gitea_user = os.environ.get('CF_IMPORT_GITEA_USER', 'crayvcs').strip()
     target_branch = "/".join([org, product_name, product_version])
     base_branch_prefix = "/".join([org, product_name]) + '/'


### PR DESCRIPTION
## Summary and Scope
This change fixes the behavior of the CF_IMPORT_GITEA_REPO environment variable such that it will be treated the same if it is an empty string or if it is not set.

## Issues and Related PRs

* Resolves [CASMINST-5876](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5876)

## Testing

### Tested on:

  * `frigg`

### Test description:
Test with IUF with vcs.repo_name property in manifest.

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

