### PR TITLE
CASMCMS-8540: Use CSM-curated alpine base image to resolve security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - dependabot: Bump `semver` from 2.13.0 to 3.0.0
+- CASMCMS-8540: Switch to CSM-curated alpine base image to resolve security vulnerabilities.
 
 ## [1.9.2] - 2023-04-11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Dockerfile for importing content into gitea instances on Shasta
-FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
 WORKDIR /
 
 # Supported Environment Variables (see README in this repository)


### PR DESCRIPTION
## Summary and Scope

The alpine base image being used contained 1 critical, 3 high, and 2 medium security vulnerabilities. Switching to the CSM-provided alpine base image resolves these (at the "cost" of using alpine 3.15.7 instead of alpine 3.15.8, which shouldn't matter for this container).

## Issues and Related PRs

- Resolves [CASMCMS-8540](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8540)

## Risks and Mitigations

Low risk -- only changing the base image slightly.

## Pull Request Checklist

- [X] Target branch correct
