### PR TITLE
CASMCMS-8531: Only do a shallow clone to reduce memory consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.4] - 2023-04-14
+
+### Fixed
+
+- CASMINST-5876: Handle `CF_IMPORT_GITEA_REPO` properly when it is the empty string
+- CASMINST-5843: Fixing permissions for certs directory for nobody user
+
 ## [1.9.3] - 2023-04-14
 
 ### Changed

--- a/import.py
+++ b/import.py
@@ -116,7 +116,7 @@ def clone_repo(gitea_base_url, org, repo_name, workdir, username, password):
         parsed.fragment
     ))
     LOGGER.info("Cloning repository: %s", repo_name)
-    return Repo.clone_from(clone_url, workdir)
+    return Repo.clone_from(clone_url, workdir, depth=1, multi_options=["--no-single-branch"])
 
 
 def get_gitea_repository(repo_name, org, gitea_url, session):
@@ -296,7 +296,7 @@ def _setup_logging():
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')  # noqa: E501
     handler.setFormatter(formatter)
     LOGGER.addHandler(handler)
-    
+
 def _setup_iuf_logging():
     """ Setup stdout IUF CLI logging for this script """
     LOGGER.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary and Scope

Reduces the memory consumption of the import script by only doing a shallow clone, so that cloning large repos doesn't result in an OOM error.

## Issues and Related PRs

* Resolves CASMCMS-8531

## Testing

### Tested on:

  * Mug

### Test description:

Validated parts of the script to check memory usage and that these changes wouldn't interfere with the operations of the rest of the script.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

