### PR TITLE
CASMCMS-8713: Temporarily modify PyYAML install procedure in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### changed
-
-- dependabot: Bump `semver` from 3.0.0 to 3.0.1
-
 ### Dependencies
 - Bump `gitpython` from 3.1.31 to 3.1.32 (#88)
+- Bump `semver` from 3.0.0 to 3.0.1
+- Temporarily modify [`Dockerfile`](Dockerfile) procedure used to install `PyYAML`, to work around https://github.com/yaml/pyyaml/issues/601
 
 ## [1.9.5] - 2023-05-31
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,41 @@ RUN apk add --upgrade --no-cache apk-tools &&  \
     curl \
     py3-pip && \
     apk -U upgrade --no-cache
-ADD requirements.txt constraints.txt ./
-RUN pip3 install --no-cache-dir -r requirements.txt && \
-    rm -rf requirements.txt constraints.txt && \
+
+# The addition of the requirements-pyyaml.txt and requirements-non-pyyaml.txt files is to work around
+# a problem installing the PyYAML Python module. A change was also made to the pip3 install commands to
+# use these files. This work around essentially forces the install of the PyYAML module to use a
+# version of Cython that is < 3.0 (this restriction was added to constraints.txt along with the changes
+# here in the Dockerfile).
+#
+# These workarounds are necessary until one of the following things happens:
+# * PyYAML publishes an update which constrains its build environment to using Cython < 3.0, so that
+#   we don't have to manually impose that constraint.
+# * A combination of Cython and PyYAML versions are released that allow PyYAML to build under Alpine using
+#   Cython >= 3.0, so that we don't need to manually constrain the Cython version.
+# * A PyYAML wheel is available for Alpine, so that the build environment is a non-issue.
+#
+# Currently there is a PyYAML PR up which would do the first item on that list: https://github.com/yaml/pyyaml/pull/702
+# If that PR merges and is added to a PyYAML release, then the following steps should be done to undo the workaround:
+#
+# * Update constraints.txt with the PyYAML version that contains the workaround
+# * Delete requirements-pyyaml.txt requirements-non-pyyaml.txt from the repository
+# * Remove requirements-pyyaml.txt requirements-non-pyyaml.txt from the ADD and rm lines in this Dockerfile
+# * Remove the Cython constraint from constraints.txt
+# * Modify the following Dockerfile lines from:
+#
+#    pip3 install --no-cache-dir -r requirements-pyyaml.txt --no-build-isolation && \
+#    pip3 install --no-cache-dir -r requirements-non-pyyaml.txt && \
+#
+#   to:
+#
+#    pip3 install --no-cache-dir -r requirements.txt && \
+
+ADD requirements.txt constraints.txt requirements-pyyaml.txt requirements-non-pyyaml.txt ./
+RUN pip3 install --upgrade pip wheel && \
+    pip3 install --no-cache-dir -r requirements-pyyaml.txt --no-build-isolation && \
+    pip3 install --no-cache-dir -r requirements-non-pyyaml.txt && \
+    rm -rf requirements.txt constraints.txt requirements-pyyaml.txt requirements-non-pyyaml.txt && \
     mkdir -p /opt/csm && \
     chown nobody:nobody /opt/csm
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
+Cython<3.0
 gitdb==4.0.10
 GitPython==3.1.32
 semver==3.0.1

--- a/requirements-non-pyyaml.txt
+++ b/requirements-non-pyyaml.txt
@@ -1,0 +1,3 @@
+-c constraints.txt
+GitPython
+semver

--- a/requirements-pyyaml.txt
+++ b/requirements-pyyaml.txt
@@ -1,0 +1,3 @@
+-c constraints.txt
+Cython
+PyYAML


### PR DESCRIPTION
## Summary and Scope

Builds started failing recently, due to https://github.com/yaml/pyyaml/issues/601. Because this repo is using an Alpine container, this PR represents the simplest workaround I was able to come up with. (Essentially, it forces the install of `PyYAML` inside the Docker container to use an older version of Cython). The PR is careful to only make this change when installing the `PyYAML` module.

This should only be a temporary workaround. There is a PR up for `PyYAML` that will allow us to remove this workaround, but it's not clear when it will be merged and released. That PR is: https://github.com/yaml/pyyaml/pull/702

This workaround PR should have no functional impact. It will just allow the builds to continue working.

## Issues and Related PRs

* https://github.com/yaml/pyyaml/issues/601
* https://github.com/yaml/pyyaml/pull/702
* Works around build failures documented in [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713)
* [Corresponding cray-product-catalog PR](https://github.com/Cray-HPE/cray-product-catalog/pull/263)
## Risks and Mitigations

Without this, the repo is unbuildable.
