### PR TITLE
CASMCMS-8713: Revert PyYAML workaround and bump PyYAML version to 6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `gitpython` from 3.1.31 to 3.1.32 (#88)
 - Bump `semver` from 3.0.0 to 3.0.1
 - Temporarily modify [`Dockerfile`](Dockerfile) procedure used to install `PyYAML`, to work around https://github.com/yaml/pyyaml/issues/601
+- Revert temporary modifications from previous item
+- Bump `PyYAML` from 6.0 to 6.0.1
+- Pin `pip` version to 23.2
+- Pin `setuptools` version to 68.0.0
+- Pin `wheel` version to 0.40.0
 
 ## [1.9.5] - 2023-05-31
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,40 +60,10 @@ RUN apk add --upgrade --no-cache apk-tools &&  \
     py3-pip && \
     apk -U upgrade --no-cache
 
-# The addition of the requirements-pyyaml.txt and requirements-non-pyyaml.txt files is to work around
-# a problem installing the PyYAML Python module. A change was also made to the pip3 install commands to
-# use these files. This work around essentially forces the install of the PyYAML module to use a
-# version of Cython that is < 3.0 (this restriction was added to constraints.txt along with the changes
-# here in the Dockerfile).
-#
-# These workarounds are necessary until one of the following things happens:
-# * PyYAML publishes an update which constrains its build environment to using Cython < 3.0, so that
-#   we don't have to manually impose that constraint.
-# * A combination of Cython and PyYAML versions are released that allow PyYAML to build under Alpine using
-#   Cython >= 3.0, so that we don't need to manually constrain the Cython version.
-# * A PyYAML wheel is available for Alpine, so that the build environment is a non-issue.
-#
-# Currently there is a PyYAML PR up which would do the first item on that list: https://github.com/yaml/pyyaml/pull/702
-# If that PR merges and is added to a PyYAML release, then the following steps should be done to undo the workaround:
-#
-# * Update constraints.txt with the PyYAML version that contains the workaround
-# * Delete requirements-pyyaml.txt requirements-non-pyyaml.txt from the repository
-# * Remove requirements-pyyaml.txt requirements-non-pyyaml.txt from the ADD and rm lines in this Dockerfile
-# * Remove the Cython constraint from constraints.txt
-# * Modify the following Dockerfile lines from:
-#
-#    pip3 install --no-cache-dir -r requirements-pyyaml.txt --no-build-isolation && \
-#    pip3 install --no-cache-dir -r requirements-non-pyyaml.txt && \
-#
-#   to:
-#
-#    pip3 install --no-cache-dir -r requirements.txt && \
-
-ADD requirements.txt constraints.txt requirements-pyyaml.txt requirements-non-pyyaml.txt ./
-RUN pip3 install --upgrade pip wheel && \
-    pip3 install --no-cache-dir -r requirements-pyyaml.txt --no-build-isolation && \
-    pip3 install --no-cache-dir -r requirements-non-pyyaml.txt && \
-    rm -rf requirements.txt constraints.txt requirements-pyyaml.txt requirements-non-pyyaml.txt && \
+ADD requirements.txt constraints.txt ./
+RUN pip3 install --no-cache-dir --upgrade pip wheel -c constraints.txt && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    rm -rf requirements.txt constraints.txt && \
     mkdir -p /opt/csm && \
     chown nobody:nobody /opt/csm
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,8 @@
-Cython<3.0
 gitdb==4.0.10
 GitPython==3.1.32
+pip==23.2
 semver==3.0.1
+setuptools==68.0.0
 smmap==5.0.0
-PyYAML==6.0
+PyYAML==6.0.1
+wheel==0.40.0

--- a/requirements-non-pyyaml.txt
+++ b/requirements-non-pyyaml.txt
@@ -1,3 +1,0 @@
--c constraints.txt
-GitPython
-semver

--- a/requirements-pyyaml.txt
+++ b/requirements-pyyaml.txt
@@ -1,3 +1,0 @@
--c constraints.txt
-Cython
-PyYAML


### PR DESCRIPTION
This reverts [my workaround from yesterday](https://github.com/Cray-HPE/cf-gitea-import/pull/89) and moves up to PyYAML 6.0.1, which avoids the build issue being seen.