### PR TITLE
CASMCMS-8885: Fixed bug in semver version sorting algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.8] - 2024-01-04
+
+### Fixed
+- CASMCMS-8885: Fixed bug in semver version sorting
+
 ## [1.9.7] - 2023-11-07
 
 ### Changed
-- copy files to target only if files exist in /shared directory.
+- CASMTRIAGE-6152: Copy files to target only if files exist in /shared directory.
 
 ## [1.9.6] - 2023-07-18
 
@@ -247,7 +252,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation @rkleinman-hpe
 
-[Unreleased]: https://github.com/Cray-HPE/cf-gitea-import/compare/v1.9.7...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cf-gitea-import/compare/v1.9.8...HEAD
+
+[1.9.8]: https://github.com/Cray-HPE/cf-gitea-import/releases/tag/v1.9.8
 
 [1.9.7]: https://github.com/Cray-HPE/cf-gitea-import/releases/tag/v1.9.7
 


### PR DESCRIPTION
## Summary and Scope

The current logic assumed that sorting a list of version strings lexically would be the same as sorting them by semver, but this is not true. This PR modifies the relevant code so that it does the sorting by semantic version. This involved some refactoring to simplify the code, as the current implementation had some unnecessary complexity. 

Some small logging improvements to the relevant section of code are also included.

## Issues and Related PRs

* Found while investigating [CASMTRIAGE-6448](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6448) (although it turned out to be unrelated to that problem)
* Resolves [CASMCMS-8885](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8885)

## Testing

I tested my updated logic on a variety of produce repos on slice and verifies that it handles them properly. I also verified that the improved logging is present and as expected.

## Risks and Mitigations

Low risk. For the most part, this modified code is simpler than what it is replacing, and was easy to test.

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cf-gitea-import/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

